### PR TITLE
[astronomer/issues#360] Add feature to install Velero

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Requires Terraform 0.12+
 ## Features:
 
 - Tiller
+- Velero (Optional)
 - Istio (Optional)
 - GCP Cloud SQL Proxy (Optional)
 - AWS Cloud Autoscaler (Optional)

--- a/variables.tf
+++ b/variables.tf
@@ -90,8 +90,8 @@ variable "extra_istio_helm_values" {
 }
 
 variable "enable_velero" {
-  default = "false"
-  type    = string
+  default = false
+  type    = bool
 }
 
 variable "extra_velero_helm_values" {

--- a/variables.tf
+++ b/variables.tf
@@ -75,7 +75,7 @@ variable "astronomer_namespace" {
 # https://github.com/hashicorp/terraform/issues/1178
 resource "null_resource" "dependency_getter" {
   triggers = {
-    my_dependencies = "${join(",", var.dependencies)}"
+    my_dependencies = join(",", var.dependencies)
   }
 }
 variable "dependencies" {
@@ -87,4 +87,30 @@ variable "extra_istio_helm_values" {
   type        = "string"
   description = "Values in raw yaml to pass to helm to override defaults in Istio Helm Chart."
   default     = ""
+}
+
+variable "enable_velero" {
+  default = "false"
+  type    = string
+}
+
+variable "extra_velero_helm_values" {
+  type        = "string"
+  default     = ""
+  description = "Vales in raw yaml to pass to helm to helm to override defaults in Velero Helm Chart."
+}
+
+variable "velero_namespace_name" {
+  default     = "velero"
+  description = "Namespace to create to install Velero"
+}
+
+variable "velero_helm_repository" {
+  default     = "stable"
+  description = "Helm repository to use to download velero chart"
+}
+
+variable "velero_helm_chart_version" {
+  default     = "2.1.6"
+  description = "Helm Chart Version to use to deploy Velero"
 }

--- a/velero.tf
+++ b/velero.tf
@@ -1,5 +1,5 @@
 resource "kubernetes_namespace" "velero" {
-  count = var.enable_velero == "true" ? 1 : 0
+  count = var.enable_velero ? 1 : 0
   metadata {
     name = var.velero_namespace_name
   }
@@ -7,7 +7,7 @@ resource "kubernetes_namespace" "velero" {
 
 # Namespace admin role
 resource "kubernetes_role" "tiller-velero" {
-  count = var.enable_velero == "true" ? 1 : 0
+  count = var.enable_velero ? 1 : 0
   metadata {
     name      = "tiller-velero"
     namespace = kubernetes_namespace.velero[0].metadata[0].name
@@ -23,7 +23,7 @@ resource "kubernetes_role" "tiller-velero" {
 
 # Namespace admin role bindings
 resource "kubernetes_role_binding" "tiller-velero" {
-  count = var.enable_velero == "true" ? 1 : 0
+  count = var.enable_velero ? 1 : 0
   metadata {
     name      = "tiller-velero"
     namespace = kubernetes_namespace.velero[0].metadata[0].name
@@ -44,7 +44,7 @@ resource "kubernetes_role_binding" "tiller-velero" {
 }
 
 resource "helm_release" "velero" {
-  count      = var.enable_velero == "true" ? 1 : 0
+  count      = var.enable_velero ? 1 : 0
   depends_on = ["kubernetes_role.tiller-velero", "kubernetes_role_binding.tiller-velero"]
   name       = "velero"
   repository = var.velero_helm_repository

--- a/velero.tf
+++ b/velero.tf
@@ -1,0 +1,59 @@
+resource "kubernetes_namespace" "velero" {
+  count = var.enable_velero == "true" ? 1 : 0
+  metadata {
+    name = var.velero_namespace_name
+  }
+}
+
+# Namespace admin role
+resource "kubernetes_role" "tiller-velero" {
+  count = var.enable_velero == "true" ? 1 : 0
+  metadata {
+    name      = "tiller-velero"
+    namespace = kubernetes_namespace.velero[0].metadata[0].name
+  }
+
+  # Read/write access to velero resources
+  rule {
+    api_groups = ["velero.io"]
+    resources  = ["*"]
+    verbs      = ["get", "list", "watch", "create", "update", "patch", "delete", "edit", "exec"]
+  }
+}
+
+# Namespace admin role bindings
+resource "kubernetes_role_binding" "tiller-velero" {
+  count = var.enable_velero == "true" ? 1 : 0
+  metadata {
+    name      = "tiller-velero"
+    namespace = kubernetes_namespace.velero[0].metadata[0].name
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Role"
+    name      = "tiller-velero"
+  }
+
+  # Users
+  subject {
+    kind      = "ServiceAccount"
+    name      = "tiller"
+    namespace = kubernetes_namespace.velero[0].metadata[0].name
+  }
+}
+
+resource "helm_release" "velero" {
+  count      = var.enable_velero == "true" ? 1 : 0
+  depends_on = ["kubernetes_role.tiller-velero", "kubernetes_role_binding.tiller-velero"]
+  name       = "velero"
+  repository = var.velero_helm_repository
+  chart      = "velero"
+  version    = var.velero_helm_chart_version
+  namespace  = kubernetes_namespace.velero[0].metadata[0].name
+  timeout    = 1200
+
+  values = [
+    var.extra_velero_helm_values,
+  ]
+}


### PR DESCRIPTION
Issue: https://github.com/astronomer/issues/issues/360

We will need to create a bucket, service account on [GCP module](https://github.com/astronomer/terraform-google-astronomer-gcp) which we will pass down in our [Cloud module ](https://github.com/astronomer/terraform-google-astronomer-cloud) by setting `extra_velero_helm_values` of this module. Will do this by creating PR's to the respective repos