### PR TITLE
Add optional Istio local gateway

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ helm.astronomer.io
 kubeconfig
 backup
 temp
+istio

--- a/istio-local-gateway.yaml
+++ b/istio-local-gateway.yaml
@@ -1,4 +1,6 @@
 ---
+# File generated using commands in following PR:
+# PR: https://github.com/astronomer/terraform-kubernetes-astronomer-system-components/pull/6
 # Source: istio/charts/gateways/templates/poddisruptionbudget.yaml
 
 apiVersion: policy/v1beta1

--- a/istio-local-gateway.yaml
+++ b/istio-local-gateway.yaml
@@ -1,6 +1,4 @@
 ---
-# File generated using commands in following PR:
-# PR: https://github.com/astronomer/terraform-kubernetes-astronomer-system-components/pull/6
 # Source: istio/charts/gateways/templates/poddisruptionbudget.yaml
 
 apiVersion: policy/v1beta1

--- a/istio-local-gateway.yaml
+++ b/istio-local-gateway.yaml
@@ -1,5 +1,3 @@
-locals {
-  istio_local_gateway_helm_values = <<EOF
 ---
 # Source: istio/charts/gateways/templates/poddisruptionbudget.yaml
 
@@ -13,7 +11,6 @@ metadata:
     heritage: Tiller
     release: release-name
     app: cluster-local-gateway
-    istio: cluster-local-gateway
 spec:
 
   minAvailable: 1
@@ -21,7 +18,6 @@ spec:
     matchLabels:
       release: release-name
       app: cluster-local-gateway
-      istio: cluster-local-gateway
 ---
 
 ---
@@ -93,13 +89,11 @@ metadata:
     heritage: Tiller
     release: release-name
     app: cluster-local-gateway
-    istio: cluster-local-gateway
 spec:
-  type: ClusterIP
+  type: LoadBalancer
   selector:
     release: release-name
     app: cluster-local-gateway
-    istio: cluster-local-gateway
   ports:
     -
       name: http2
@@ -150,17 +144,15 @@ metadata:
     heritage: Tiller
     release: release-name
     app: cluster-local-gateway
-    istio: cluster-local-gateway
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: cluster-local-gateway
-      istio: cluster-local-gateway
   strategy:
     rollingUpdate:
-      maxSurge:
-      maxUnavailable:
+      maxSurge: 
+      maxUnavailable: 
   template:
     metadata:
       labels:
@@ -168,7 +160,6 @@ spec:
         heritage: Tiller
         release: release-name
         app: cluster-local-gateway
-        istio: cluster-local-gateway
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
@@ -227,7 +218,7 @@ spec:
           resources:
             requests:
               cpu: 10m
-
+            
           env:
           - name: NODE_NAME
             valueFrom:
@@ -296,7 +287,7 @@ spec:
         secret:
           secretName: "istio-clusterlocalgateway-ca-certs"
           optional: true
-      affinity:
+      affinity:      
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
@@ -328,6 +319,75 @@ spec:
               - key: beta.kubernetes.io/arch
                 operator: In
                 values:
-                - "s390x"
-EOF
-}
+                - "s390x"      
+---
+
+---
+# Source: istio/charts/gateways/templates/autoscale.yaml
+
+
+---
+# Source: istio/charts/gateways/templates/preconfigured.yaml
+
+
+---
+# Source: istio/charts/gateways/templates/role.yaml
+
+
+---
+# Source: istio/charts/gateways/templates/rolebindings.yaml
+
+
+---
+# Source: istio/charts/mixer/templates/autoscale.yaml
+
+
+---
+# Source: istio/charts/mixer/templates/clusterrole.yaml
+
+
+---
+# Source: istio/charts/mixer/templates/clusterrolebinding.yaml
+
+
+---
+# Source: istio/charts/mixer/templates/config.yaml
+
+
+---
+# Source: istio/charts/mixer/templates/deployment.yaml
+ 
+
+---
+# Source: istio/charts/mixer/templates/poddisruptionbudget.yaml
+
+
+---
+# Source: istio/charts/mixer/templates/service.yaml
+
+
+
+---
+# Source: istio/charts/mixer/templates/serviceaccount.yaml
+
+
+---
+# Source: istio/templates/configmap.yaml
+
+
+---
+# Source: istio/templates/endpoints.yaml
+
+
+---
+# Source: istio/templates/install-custom-resources.sh.tpl
+
+
+---
+# Source: istio/templates/service.yaml
+
+
+---
+# Source: istio/templates/sidecar-injector-configmap.yaml
+
+

--- a/istio.tf
+++ b/istio.tf
@@ -51,7 +51,7 @@ resource "helm_release" "istio" {
   wait       = true
 
   values = var.enable_istio_local_gateway ? [
-    local.istio_local_gateway_helm_values, var.extra_istio_helm_values] : [var.extra_istio_helm_values]
+  local.istio_local_gateway_helm_values, var.extra_istio_helm_values] : [var.extra_istio_helm_values]
 
   dynamic "set" {
     for_each = var.enable_istio_local_gateway ? local.istio_local_gateway_helm_set_list : {}

--- a/istio.tf
+++ b/istio.tf
@@ -51,9 +51,21 @@ resource "helm_release" "istio" {
   wait       = true
 
   values = [
-    var.enable_istio_local_gateway ? local.istio_local_gateway_helm_values : "",
     var.extra_istio_helm_values,
   ]
+
+}
+
+resource "helm_release" "istio_local_gatewaty" {
+  depends_on = [helm_release.istio, null_resource.helm_repo]
+  count      = var.enable_istio_local_gateway ? 1 : 0
+  name       = "istio"
+  chart      = "./istio/install/kubernetes/helm/istio"
+  namespace  = kubernetes_namespace.istio_system[0].metadata[0].name
+  version    = var.istio_helm_release_version
+  wait       = true
+
+  values = [local.istio_local_gateway_helm_values]
 
   dynamic "set" {
     for_each = var.enable_istio_local_gateway ? local.istio_local_gateway_helm_set_list : {}

--- a/istio.tf
+++ b/istio.tf
@@ -51,29 +51,8 @@ resource "helm_release" "istio" {
   wait       = true
 
   values = [
-    var.extra_istio_helm_values,
+    local.istio_local_gateway_helm_values, var.extra_istio_helm_values
   ]
-
-  dynamic "set" {
-    for_each = var.istio_local_development ? map("gateways.istio-ingressgateway.type", "NodePort") : {}
-    content {
-      name  = set.key
-      value = set.value
-    }
-  }
-
-}
-
-resource "helm_release" "istio_local_gatewaty" {
-  depends_on = [helm_release.istio, null_resource.helm_repo]
-  count      = var.enable_istio_local_gateway ? 1 : 0
-  name       = "istio"
-  chart      = "./istio/install/kubernetes/helm/istio"
-  namespace  = kubernetes_namespace.istio_system[0].metadata[0].name
-  version    = var.istio_helm_release_version
-  wait       = true
-
-  values = [local.istio_local_gateway_helm_values]
 
   dynamic "set" {
     for_each = var.enable_istio_local_gateway ? local.istio_local_gateway_helm_set_list : {}

--- a/istio.tf
+++ b/istio.tf
@@ -50,9 +50,8 @@ resource "helm_release" "istio" {
   version    = var.istio_helm_release_version
   wait       = true
 
-  values = [
-    local.istio_local_gateway_helm_values, var.extra_istio_helm_values
-  ]
+  values = var.enable_istio_local_gateway ? [
+    local.istio_local_gateway_helm_values, var.extra_istio_helm_values] : [var.extra_istio_helm_values]
 
   dynamic "set" {
     for_each = var.enable_istio_local_gateway ? local.istio_local_gateway_helm_set_list : {}

--- a/istio.tf
+++ b/istio.tf
@@ -52,12 +52,4 @@ resource "helm_release" "istio" {
 
   values = var.enable_istio_local_gateway ? [
   local.istio_local_gateway_helm_values, var.extra_istio_helm_values] : [var.extra_istio_helm_values]
-
-  dynamic "set" {
-    for_each = var.enable_istio_local_gateway ? local.istio_local_gateway_helm_set_list : {}
-    content {
-      name  = set.key
-      value = set.value
-    }
-  }
 }

--- a/istio.tf
+++ b/istio.tf
@@ -54,6 +54,14 @@ resource "helm_release" "istio" {
     var.extra_istio_helm_values,
   ]
 
+  dynamic "set" {
+    for_each = var.istio_local_development ? map("gateways.istio-ingressgateway.type", "NodePort") : {}
+    content {
+      name  = set.key
+      value = set.value
+    }
+  }
+
 }
 
 resource "helm_release" "istio_local_gatewaty" {

--- a/istio.tf
+++ b/istio.tf
@@ -50,6 +50,5 @@ resource "helm_release" "istio" {
   version    = var.istio_helm_release_version
   wait       = true
 
-  values = var.enable_istio_local_gateway ? [
-  local.istio_local_gateway_helm_values, var.extra_istio_helm_values] : [var.extra_istio_helm_values]
+  values = compact([var.enable_istio_local_gateway ? local.istio_local_gateway_helm_values : "", var.extra_istio_helm_values])
 }

--- a/istio.tf
+++ b/istio.tf
@@ -63,8 +63,4 @@ resource "null_resource" "istio_local_gateway" {
       KUBECONFIG = var.kubeconfig_path
     }
   }
-
-  triggers = {
-    istio_local_gateway_file = file("${path.module}/istio-local-gateway.yaml")
-  }
 }

--- a/istio.tf
+++ b/istio.tf
@@ -54,4 +54,12 @@ resource "helm_release" "istio" {
     var.enable_istio_local_gateway ? local.istio_local_gateway_helm_values : "",
     var.extra_istio_helm_values,
   ]
+
+  dynamic "set" {
+    for_each = var.enable_istio_local_gateway ? local.istio_local_gateway_helm_set_list : {}
+    content {
+      name  = set.key
+      value = set.value
+    }
+  }
 }

--- a/istio.tf
+++ b/istio.tf
@@ -63,4 +63,8 @@ resource "null_resource" "istio_local_gateway" {
       KUBECONFIG = var.kubeconfig_path
     }
   }
+
+  triggers = {
+    istio_local_gateway_file = file("${path.module}/istio-local-gateway.yaml")
+  }
 }

--- a/istio.tf
+++ b/istio.tf
@@ -50,8 +50,17 @@ resource "helm_release" "istio" {
   version    = var.istio_helm_release_version
   wait       = true
 
-  values = [
-    var.enable_istio_local_gateway ? local.istio_local_gateway_helm_values : "",
-    var.extra_istio_helm_values,
-  ]
+  values = [var.extra_istio_helm_values]
+}
+
+resource "null_resource" "istio_local_gateway" {
+  count = var.enable_istio_local_gateway ? 1 : 0
+
+  provisioner "local-exec" {
+    command = "kubectl apply -f ${path.module}/istio-local-gateway.yaml"
+
+    environment = {
+      KUBECONFIG = var.kubeconfig_path
+    }
+  }
 }

--- a/istio.tf
+++ b/istio.tf
@@ -50,17 +50,8 @@ resource "helm_release" "istio" {
   version    = var.istio_helm_release_version
   wait       = true
 
-  values = [var.extra_istio_helm_values]
-}
-
-resource "null_resource" "istio_local_gateway" {
-  count = var.enable_istio_local_gateway ? 1 : 0
-
-  provisioner "local-exec" {
-    command = "kubectl apply -f ${path.module}/istio-local-gateway.yaml"
-
-    environment = {
-      KUBECONFIG = var.kubeconfig_path
-    }
-  }
+  values = [
+    var.enable_istio_local_gateway ? local.istio_local_gateway_helm_values : "",
+    var.extra_istio_helm_values,
+  ]
 }

--- a/istio.tf
+++ b/istio.tf
@@ -22,7 +22,7 @@ resource "null_resource" "helm_repo" {
   }
 
   triggers = {
-    build_number = "${timestamp()}"
+    build_number = timestamp()
   }
 }
 
@@ -50,5 +50,8 @@ resource "helm_release" "istio" {
   version    = var.istio_helm_release_version
   wait       = true
 
-  values = [var.extra_istio_helm_values]
+  values = [
+    var.enable_istio_local_gateway ? local.istio_local_gateway_helm_values : "",
+    var.extra_istio_helm_values,
+  ]
 }

--- a/locals.tf
+++ b/locals.tf
@@ -6,27 +6,15 @@ locals {
     "gateways.custom-gateway.labels.app"                   = "cluster-local-gateway"
     "gateways.custom-gateway.labels.istio"                 = "cluster-local-gateway"
     "gateways.custom-gateway.type"                         = "ClusterIP"
-    "gateways.istio-ingressgateway.enabled"                = "false"
     "gateways.istio-egressgateway.enabled"                 = "false"
     "gateways.istio-ilbgateway.enabled"                    = "false"
   }
 
   istio_local_gateway_helm_values = <<EOF
 ---
-
 # Common settings.
 global:
-  # Omit the istio-sidecar-injector configmap when generate a
-  # standalone gateway. Gateways may be created in namespaces other
-  # than `istio-system` and we don't want to re-create the injector
-  # configmap in those.
-  omitSidecarInjectorConfigMap: true
-
-  # Istio control plane namespace: This specifies where the Istio control
-  # plane was installed earlier.  Modify this if you installed the control
-  # plane in a different namespace than istio-system.
   istioNamespace: istio-system
-
   proxy:
     # Sets the destination Statsd in envoy (the value of the "--statsdUdpAddress" proxy argument
     # would be <host>:<port>).
@@ -37,8 +25,6 @@ global:
       enabled: false
       host: # example: statsd-svc.istio-system
       port: # example: 9125
-
-
 #
 # Gateways Configuration
 # By default (if enabled) a pair of Ingress and Egress Gateways will be created for the mesh.
@@ -48,7 +34,6 @@ global:
 #
 gateways:
   enabled: true
-
   cluster-local-gateway:
     enabled: true
     labels:
@@ -115,40 +100,5 @@ gateways:
     - name: clusterlocalgateway-ca-certs
       secretName: istio-clusterlocalgateway-ca-certs
       mountPath: /etc/istio/clusterlocalgateway-ca-certs
-
-# all other components are disabled except the gateways
-security:
-  enabled: false
-
-sidecarInjectorWebhook:
-  enabled: false
-
-galley:
-  enabled: false
-
-mixer:
-  policy:
-    enabled: false
-  telemetry:
-    enabled: false
-
-pilot:
-  enabled: false
-
-grafana:
-  enabled: false
-
-prometheus:
-  enabled: false
-
-tracing:
-  enabled: false
-
-kiali:
-  enabled: false
-
-certmanager:
-  enabled: false
-
 EOF
 }

--- a/locals.tf
+++ b/locals.tf
@@ -6,8 +6,6 @@ locals {
     "gateways.custom-gateway.labels.app"                   = "cluster-local-gateway"
     "gateways.custom-gateway.labels.istio"                 = "cluster-local-gateway"
     "gateways.custom-gateway.type"                         = "ClusterIP"
-    "gateways.istio-egressgateway.enabled"                 = "false"
-    "gateways.istio-ilbgateway.enabled"                    = "false"
   }
 
   istio_local_gateway_helm_values = <<EOF

--- a/locals.tf
+++ b/locals.tf
@@ -26,5 +26,7 @@ gateways:
     enabled: false
   istio-ilbgateway:
     enabled: false
+  istio-ingressgateway:
+    enabled: false
 EOF
 }

--- a/locals.tf
+++ b/locals.tf
@@ -3,62 +3,23 @@ locals {
 ---
 gateways:
   cluster-local-gateway:
-    autoscaleMax: 5
-    autoscaleMin: 1
-    cpu:
-      targetAverageUtilization: 80
     enabled: true
-    externalIPs: []
-    labels:
-      app: cluster-local-gateway
-    loadBalancerIP: ""
-    loadBalancerSourceRanges: {}
-    podAnnotations: {}
-    ports:
-    - name: http2
-      port: 80
-      targetPort: 80
-    - name: https
-      port: 443
-    - name: tcp
-      port: 31400
-    - name: tcp-pilot-grpc-tls
-      port: 15011
-      targetPort: 15011
-    - name: tcp-citadel-grpc-tls
-      port: 8060
-      targetPort: 8060
-    - name: http2-kiali
-      port: 15029
-      targetPort: 15029
-    - name: http2-prometheus
-      port: 15030
-      targetPort: 15030
-    - name: http2-grafana
-      port: 15031
-      targetPort: 15031
-    - name: http2-tracing
-      port: 15032
-      targetPort: 15032
-    replicaCount: 1
-    resources: {}
-    secretVolumes:
-    - mountPath: /etc/istio/clusterlocalgateway-certs
-      name: clusterlocalgateway-certs
-      secretName: istio-clusterlocalgateway-certs
-    - mountPath: /etc/istio/clusterlocalgateway-ca-certs
-      name: clusterlocalgateway-ca-certs
-      secretName: istio-clusterlocalgateway-ca-certs
-    serviceAnnotations: {}
-    type: LoadBalancer
-  custom-gateway:
     autoscaleMax: 1
     autoscaleMin: 1
     cpu:
       targetAverageUtilization: 60
+    enabled: true
     labels:
       app: cluster-local-gateway
       istio: cluster-local-gateway
+    ports:
+      - name: status-port
+        port: 15020
+      - name: http2
+        port: 80
+        targetPort: 8080
+      - name: https
+        port: 443
     type: ClusterIP
   enabled: true
   istio-egressgateway:

--- a/locals.tf
+++ b/locals.tf
@@ -1,102 +1,76 @@
 locals {
-  istio_local_gateway_helm_set_list = {
-    "gateways.custom-gateway.autoscaleMin"                 = "1"
-    "gateways.custom-gateway.autoscaleMax"                 = "1"
-    "gateways.custom-gateway.cpu.targetAverageUtilization" = "60"
-    "gateways.custom-gateway.labels.app"                   = "cluster-local-gateway"
-    "gateways.custom-gateway.labels.istio"                 = "cluster-local-gateway"
-    "gateways.custom-gateway.type"                         = "ClusterIP"
-  }
-
   istio_local_gateway_helm_values = <<EOF
 ---
-# Common settings.
+gateways:
+  cluster-local-gateway:
+    autoscaleMax: 5
+    autoscaleMin: 1
+    cpu:
+      targetAverageUtilization: 80
+    enabled: true
+    externalIPs: []
+    labels:
+      app: cluster-local-gateway
+    loadBalancerIP: ""
+    loadBalancerSourceRanges: {}
+    podAnnotations: {}
+    ports:
+    - name: http2
+      port: 80
+      targetPort: 80
+    - name: https
+      port: 443
+    - name: tcp
+      port: 31400
+    - name: tcp-pilot-grpc-tls
+      port: 15011
+      targetPort: 15011
+    - name: tcp-citadel-grpc-tls
+      port: 8060
+      targetPort: 8060
+    - name: http2-kiali
+      port: 15029
+      targetPort: 15029
+    - name: http2-prometheus
+      port: 15030
+      targetPort: 15030
+    - name: http2-grafana
+      port: 15031
+      targetPort: 15031
+    - name: http2-tracing
+      port: 15032
+      targetPort: 15032
+    replicaCount: 1
+    resources: {}
+    secretVolumes:
+    - mountPath: /etc/istio/clusterlocalgateway-certs
+      name: clusterlocalgateway-certs
+      secretName: istio-clusterlocalgateway-certs
+    - mountPath: /etc/istio/clusterlocalgateway-ca-certs
+      name: clusterlocalgateway-ca-certs
+      secretName: istio-clusterlocalgateway-ca-certs
+    serviceAnnotations: {}
+    type: LoadBalancer
+  custom-gateway:
+    autoscaleMax: 1
+    autoscaleMin: 1
+    cpu:
+      targetAverageUtilization: 60
+    labels:
+      app: cluster-local-gateway
+      istio: cluster-local-gateway
+    type: ClusterIP
+  enabled: true
+  istio-egressgateway:
+    enabled: false
+  istio-ilbgateway:
+    enabled: false
 global:
   istioNamespace: istio-system
   proxy:
-    # Sets the destination Statsd in envoy (the value of the "--statsdUdpAddress" proxy argument
-    # would be <host>:<port>).
-    # Disabled by default.
-    # The istio-statsd-prom-bridge is deprecated and should not be used moving forward.
     envoyStatsd:
-      # If enabled is set to true, host and port must also be provided. Istio no longer provides a statsd collector.
       enabled: false
-      host: # example: statsd-svc.istio-system
-      port: # example: 9125
-#
-# Gateways Configuration
-# By default (if enabled) a pair of Ingress and Egress Gateways will be created for the mesh.
-# You can add more gateways in addition to the defaults but make sure those are uniquely named
-# and that NodePorts are not conflicting.
-# Disable specific gateway by setting the `enabled` to false.
-#
-gateways:
-  enabled: true
-  cluster-local-gateway:
-    enabled: true
-    labels:
-      app: cluster-local-gateway
-    replicaCount: 1
-    autoscaleMin: 1
-    autoscaleMax: 5
-    resources: {}
-      # limits:
-      #  cpu: 100m
-      #  memory: 128Mi
-      #requests:
-      #  cpu: 1800m
-      #  memory: 256Mi
-    cpu:
-      targetAverageUtilization: 80
-    loadBalancerIP: ""
-    loadBalancerSourceRanges: {}
-    externalIPs: []
-    serviceAnnotations: {}
-    podAnnotations: {}
-    type: LoadBalancer #change to NodePort, ClusterIP or LoadBalancer if need be
-    #externalTrafficPolicy: Local #change to Local to preserve source IP or Cluster for default behaviour or leave commented out
-    ports:
-      ## You can add custom gateway ports
-    - port: 80
-      targetPort: 80
-      name: http2
-      # nodePort: 31380
-    - port: 443
-      name: https
-      # nodePort: 31390
-    - port: 31400
-      name: tcp
-      # nodePort: 31400
-    # Pilot and Citadel MTLS ports are enabled in gateway - but will only redirect
-    # to pilot/citadel if global.meshExpansion settings are enabled.
-    - port: 15011
-      targetPort: 15011
-      name: tcp-pilot-grpc-tls
-    - port: 8060
-      targetPort: 8060
-      name: tcp-citadel-grpc-tls
-    # Addon ports for kiali are enabled in gateway - but will only redirect if
-    # the gateway configuration for the various components are enabled.
-    - port: 15029
-      targetPort: 15029
-      name: http2-kiali
-    # Telemetry-related ports are enabled in gateway - but will only redirect if
-    # the gateway configuration for the various components are enabled.
-    - port: 15030
-      targetPort: 15030
-      name: http2-prometheus
-    - port: 15031
-      targetPort: 15031
-      name: http2-grafana
-    - port: 15032
-      targetPort: 15032
-      name: http2-tracing
-    secretVolumes:
-    - name: clusterlocalgateway-certs
-      secretName: istio-clusterlocalgateway-certs
-      mountPath: /etc/istio/clusterlocalgateway-certs
-    - name: clusterlocalgateway-ca-certs
-      secretName: istio-clusterlocalgateway-ca-certs
-      mountPath: /etc/istio/clusterlocalgateway-ca-certs
+      host: null
+      port: null
 EOF
 }

--- a/locals.tf
+++ b/locals.tf
@@ -65,12 +65,5 @@ gateways:
     enabled: false
   istio-ilbgateway:
     enabled: false
-global:
-  istioNamespace: istio-system
-  proxy:
-    envoyStatsd:
-      enabled: false
-      host: null
-      port: null
 EOF
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,333 @@
+locals {
+  istio_local_gateway_helm_values = <<EOF
+---
+# Source: istio/charts/gateways/templates/poddisruptionbudget.yaml
+
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: cluster-local-gateway
+  namespace: istio-system
+  labels:
+    chart: gateways
+    heritage: Tiller
+    release: release-name
+    app: cluster-local-gateway
+    istio: cluster-local-gateway
+spec:
+
+  minAvailable: 1
+  selector:
+    matchLabels:
+      release: release-name
+      app: cluster-local-gateway
+      istio: cluster-local-gateway
+---
+
+---
+# Source: istio/charts/gateways/templates/serviceaccount.yaml
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cluster-local-gateway-service-account
+  namespace: istio-system
+  labels:
+    app: cluster-local-gateway
+    chart: gateways
+    heritage: Tiller
+    release: release-name
+---
+
+
+---
+# Source: istio/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: istio-multi
+  namespace: istio-system
+
+---
+# Source: istio/templates/clusterrole.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: istio-reader
+rules:
+  - apiGroups: ['']
+    resources: ['nodes', 'pods', 'services', 'endpoints', "replicationcontrollers"]
+    verbs: ['get', 'watch', 'list']
+  - apiGroups: ["extensions", "apps"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+
+---
+# Source: istio/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: istio-multi
+  labels:
+    chart: istio-1.3.0
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: istio-reader
+subjects:
+- kind: ServiceAccount
+  name: istio-multi
+  namespace: istio-system
+
+---
+# Source: istio/charts/gateways/templates/service.yaml
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: cluster-local-gateway
+  namespace: istio-system
+  annotations:
+  labels:
+    chart: gateways
+    heritage: Tiller
+    release: release-name
+    app: cluster-local-gateway
+    istio: cluster-local-gateway
+spec:
+  type: ClusterIP
+  selector:
+    release: release-name
+    app: cluster-local-gateway
+    istio: cluster-local-gateway
+  ports:
+    -
+      name: http2
+      port: 80
+      targetPort: 80
+    -
+      name: https
+      port: 443
+    -
+      name: tcp
+      port: 31400
+    -
+      name: tcp-pilot-grpc-tls
+      port: 15011
+      targetPort: 15011
+    -
+      name: tcp-citadel-grpc-tls
+      port: 8060
+      targetPort: 8060
+    -
+      name: http2-kiali
+      port: 15029
+      targetPort: 15029
+    -
+      name: http2-prometheus
+      port: 15030
+      targetPort: 15030
+    -
+      name: http2-grafana
+      port: 15031
+      targetPort: 15031
+    -
+      name: http2-tracing
+      port: 15032
+      targetPort: 15032
+---
+
+---
+# Source: istio/charts/gateways/templates/deployment.yaml
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-local-gateway
+  namespace: istio-system
+  labels:
+    chart: gateways
+    heritage: Tiller
+    release: release-name
+    app: cluster-local-gateway
+    istio: cluster-local-gateway
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cluster-local-gateway
+      istio: cluster-local-gateway
+  strategy:
+    rollingUpdate:
+      maxSurge:
+      maxUnavailable:
+  template:
+    metadata:
+      labels:
+        chart: gateways
+        heritage: Tiller
+        release: release-name
+        app: cluster-local-gateway
+        istio: cluster-local-gateway
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: cluster-local-gateway-service-account
+      containers:
+        - name: istio-proxy
+          image: "docker.io/istio/proxyv2:1.3.0"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 80
+            - containerPort: 443
+            - containerPort: 31400
+            - containerPort: 15011
+            - containerPort: 8060
+            - containerPort: 15029
+            - containerPort: 15030
+            - containerPort: 15031
+            - containerPort: 15032
+            - containerPort: 15090
+              protocol: TCP
+              name: http-envoy-prom
+          args:
+          - proxy
+          - router
+          - --domain
+          - $(POD_NAMESPACE).svc.cluster.local
+          - --log_output_level=default:info
+          - --drainDuration
+          - '45s' #drainDuration
+          - --parentShutdownDuration
+          - '1m0s' #parentShutdownDuration
+          - --connectTimeout
+          - '10s' #connectTimeout
+          - --serviceCluster
+          - cluster-local-gateway
+          - --zipkinAddress
+          - zipkin.istio-system:9411
+          - --proxyAdminPort
+          - "15000"
+          - --statusPort
+          - "15020"
+          - --controlPlaneAuthPolicy
+          - NONE
+          - --discoveryAddress
+          - istio-pilot.istio-system:15010
+          readinessProbe:
+            failureThreshold: 30
+            httpGet:
+              path: /healthz/ready
+              port: 15020
+              scheme: HTTP
+            initialDelaySeconds: 1
+            periodSeconds: 2
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            requests:
+              cpu: 10m
+
+          env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: spec.nodeName
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+          - name: INSTANCE_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.podIP
+          - name: HOST_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.hostIP
+          - name: SERVICE_ACCOUNT
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.serviceAccountName
+          - name: ISTIO_META_POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+          - name: ISTIO_META_CONFIG_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: SDS_ENABLED
+            value: "false"
+          - name: ISTIO_META_WORKLOAD_NAME
+            value: cluster-local-gateway
+          - name: ISTIO_META_OWNER
+            value: kubernetes://api/apps/v1/namespaces/istio-system/deployments/cluster-local-gateway
+          volumeMounts:
+          - name: istio-certs
+            mountPath: /etc/certs
+            readOnly: true
+          - name: clusterlocalgateway-certs
+            mountPath: "/etc/istio/clusterlocalgateway-certs"
+            readOnly: true
+          - name: clusterlocalgateway-ca-certs
+            mountPath: "/etc/istio/clusterlocalgateway-ca-certs"
+            readOnly: true
+      volumes:
+      - name: istio-certs
+        secret:
+          secretName: istio.cluster-local-gateway-service-account
+          optional: true
+      - name: clusterlocalgateway-certs
+        secret:
+          secretName: "istio-clusterlocalgateway-certs"
+          optional: true
+      - name: clusterlocalgateway-ca-certs
+        secret:
+          secretName: "istio-clusterlocalgateway-ca-certs"
+          optional: true
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - "amd64"
+                - "ppc64le"
+                - "s390x"
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - "amd64"
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - "ppc64le"
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - "s390x"
+EOF
+}

--- a/locals.tf
+++ b/locals.tf
@@ -1,3 +1,5 @@
+locals {
+  istio_local_gateway_helm_values = <<EOF
 ---
 # Source: istio/charts/gateways/templates/poddisruptionbudget.yaml
 
@@ -11,6 +13,7 @@ metadata:
     heritage: Tiller
     release: release-name
     app: cluster-local-gateway
+    istio: cluster-local-gateway
 spec:
 
   minAvailable: 1
@@ -18,6 +21,7 @@ spec:
     matchLabels:
       release: release-name
       app: cluster-local-gateway
+      istio: cluster-local-gateway
 ---
 
 ---
@@ -89,11 +93,13 @@ metadata:
     heritage: Tiller
     release: release-name
     app: cluster-local-gateway
+    istio: cluster-local-gateway
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   selector:
     release: release-name
     app: cluster-local-gateway
+    istio: cluster-local-gateway
   ports:
     -
       name: http2
@@ -144,15 +150,17 @@ metadata:
     heritage: Tiller
     release: release-name
     app: cluster-local-gateway
+    istio: cluster-local-gateway
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: cluster-local-gateway
+      istio: cluster-local-gateway
   strategy:
     rollingUpdate:
-      maxSurge: 
-      maxUnavailable: 
+      maxSurge:
+      maxUnavailable:
   template:
     metadata:
       labels:
@@ -160,6 +168,7 @@ spec:
         heritage: Tiller
         release: release-name
         app: cluster-local-gateway
+        istio: cluster-local-gateway
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
@@ -218,7 +227,7 @@ spec:
           resources:
             requests:
               cpu: 10m
-            
+
           env:
           - name: NODE_NAME
             valueFrom:
@@ -287,7 +296,7 @@ spec:
         secret:
           secretName: "istio-clusterlocalgateway-ca-certs"
           optional: true
-      affinity:      
+      affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
@@ -319,75 +328,6 @@ spec:
               - key: beta.kubernetes.io/arch
                 operator: In
                 values:
-                - "s390x"      
----
-
----
-# Source: istio/charts/gateways/templates/autoscale.yaml
-
-
----
-# Source: istio/charts/gateways/templates/preconfigured.yaml
-
-
----
-# Source: istio/charts/gateways/templates/role.yaml
-
-
----
-# Source: istio/charts/gateways/templates/rolebindings.yaml
-
-
----
-# Source: istio/charts/mixer/templates/autoscale.yaml
-
-
----
-# Source: istio/charts/mixer/templates/clusterrole.yaml
-
-
----
-# Source: istio/charts/mixer/templates/clusterrolebinding.yaml
-
-
----
-# Source: istio/charts/mixer/templates/config.yaml
-
-
----
-# Source: istio/charts/mixer/templates/deployment.yaml
- 
-
----
-# Source: istio/charts/mixer/templates/poddisruptionbudget.yaml
-
-
----
-# Source: istio/charts/mixer/templates/service.yaml
-
-
-
----
-# Source: istio/charts/mixer/templates/serviceaccount.yaml
-
-
----
-# Source: istio/templates/configmap.yaml
-
-
----
-# Source: istio/templates/endpoints.yaml
-
-
----
-# Source: istio/templates/install-custom-resources.sh.tpl
-
-
----
-# Source: istio/templates/service.yaml
-
-
----
-# Source: istio/templates/sidecar-injector-configmap.yaml
-
-
+                - "s390x"
+EOF
+}

--- a/variables.tf
+++ b/variables.tf
@@ -165,8 +165,3 @@ variable "enable_istio_local_gateway" {
   type    = bool
   default = false
 }
-
-variable "istio_local_development" {
-  default     = false
-  description = "When using kubernetes kind for creating cluster turn this to true"
-}

--- a/variables.tf
+++ b/variables.tf
@@ -165,3 +165,8 @@ variable "enable_istio_local_gateway" {
   type    = bool
   default = false
 }
+
+variable "istio_local_development" {
+  default     = false
+  description = "When using kubernetes kind for creating cluster turn this to true"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,5 @@
 variable "enable_istio" {
-  default = "true"
+  default = "false"
   type    = string
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,5 @@
 variable "enable_istio" {
-  default = "false"
+  default = "true"
   type    = string
 }
 
@@ -159,4 +159,9 @@ variable "tiller_node_selectors" {
   type        = map(string)
   default     = {}
   description = "Map of {label: value} to use as node selector for Tiller deployment"
+}
+
+variable "enable_istio_local_gateway" {
+  type    = bool
+  default = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,5 @@
 variable "enable_istio" {
-  default = "true"
+  default = "false"
   type    = string
 }
 
@@ -164,4 +164,9 @@ variable "tiller_node_selectors" {
 variable "enable_istio_local_gateway" {
   type    = bool
   default = false
+}
+
+variable "kubeconfig_path" {
+  default = ""
+  type    = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,5 @@
 variable "enable_istio" {
-  default = "false"
+  default = "true"
   type    = string
 }
 
@@ -164,9 +164,4 @@ variable "tiller_node_selectors" {
 variable "enable_istio_local_gateway" {
   type    = bool
   default = false
-}
-
-variable "kubeconfig_path" {
-  default = ""
-  type    = string
 }


### PR DESCRIPTION
- `istio-local-gateway.yaml` the file is produced by the following:

```bash
curl -L https://git.io/getLatestIstio | ISTIO_VERSION=1.3.0 sh -
mv istio-1.3.0 istio
cat istio/install/kubernetes/helm/istio/example-values/values-istio-gateways.yaml | sed -e "s/custom-gateway/cluster-local-gateway/g" -e "s/customgateway/clusterlocalgateway/g" > ./istio-local-gateway.yaml

helm template --namespace=istio-system \
  --set gateways.custom-gateway.autoscaleMin=1 \
  --set gateways.custom-gateway.autoscaleMax=1 \
  --set gateways.custom-gateway.cpu.targetAverageUtilization=60 \
  --set gateways.custom-gateway.labels.app='cluster-local-gateway' \
  --set gateways.custom-gateway.labels.istio='cluster-local-gateway' \
  --set gateways.custom-gateway.type='ClusterIP' \
  --set gateways.istio-ingressgateway.enabled=false \
  --set gateways.istio-egressgateway.enabled=false \
  --set gateways.istio-ilbgateway.enabled=false \
  istio/install/kubernetes/helm/istio -f istio-local-gateway.yaml > istio-local-gateway.yaml

```