### PR TITLE
Add safe-to-evict annoation to cloud sql proxy

### DIFF
--- a/cloud_sql_proxy.tf
+++ b/cloud_sql_proxy.tf
@@ -37,4 +37,8 @@ resource "helm_release" "cloud_sql_proxy" {
     name  = "cloudsql.instances[0].port"
     value = "5432"
   }
+  set {
+    name  = "podAnnotations.cluster-autoscaler\\.kubernetes\\.io/safe-to-evict"
+    value = true
+  }
 }


### PR DESCRIPTION
This PR adds the safe-to-evict to our google cloud sql proxy pods. This will allow these pods to be evicted to scale our clusters down. It's needed because these pods are using localStroage.

Syntax was pulled from here: https://github.com/terraform-providers/terraform-provider-helm/issues/125

Cloud SQL chart Values: https://github.com/rimusz/charts/blob/master/stable/gcloud-sqlproxy/values.yaml#L135-L136