### PR TITLE
Update to new helm stable repo

### DIFF
--- a/aws_cluster_autoscaler.tf
+++ b/aws_cluster_autoscaler.tf
@@ -13,7 +13,7 @@ resource "helm_release" "cluster_autoscaler" {
   name       = "cluster-autoscaler"
   version    = "7.3.4"
   chart      = "cluster-autoscaler"
-  repository = "https://kubernetes-charts.storage.googleapis.com"
+  repository = "https://charts.helm.sh/stable"
   namespace  = kubernetes_namespace.cluster_autoscaler[0].metadata[0].name
   wait       = true
 


### PR DESCRIPTION
Switch out deprecated helm repo for new stable repo.

- <https://www.cncf.io/blog/2020/11/05/helm-chart-repository-deprecation-update/>
- <https://helm.sh/docs/faq/#i-am-getting-a-warning-about-unable-to-get-an-update-from-the-stable-chart-repository>

Relates to astronomer/issues#2003