### PR TITLE
Update culster-autoscaler chart astronomer/issues#2254

### DIFF
--- a/aws_cluster_autoscaler.tf
+++ b/aws_cluster_autoscaler.tf
@@ -11,9 +11,9 @@ resource "kubernetes_namespace" "cluster_autoscaler" {
 resource "helm_release" "cluster_autoscaler" {
   count      = var.enable_aws_cluster_autoscaler ? 1 : 0
   name       = "cluster-autoscaler"
-  version    = "7.3.4"
-  chart      = "cluster-autoscaler"
-  repository = "https://kubernetes-charts.storage.googleapis.com"
+  version    = "1.1.1"
+  chart      = "cluster-autoscaler-chart"
+  repository = "https://kubernetes.github.io/autoscaler"
   namespace  = kubernetes_namespace.cluster_autoscaler[0].metadata[0].name
   wait       = true
 


### PR DESCRIPTION
- The current `cluster-autoscaler` helm chart we are using (https://github.com/helm/charts/tree/master/stable/cluster-autoscaler) has been deprecated and moved to https://github.com/kubernetes/autoscaler
- Update helm repository, chart name and chart version
- Related to https://github.com/astronomer/issues/issues/2254