### PR TITLE
Remove git.io

### DIFF
--- a/istio.tf
+++ b/istio.tf
@@ -26,7 +26,7 @@ resource "null_resource" "helm_repo" {
     set -xe
     cd ${path.root}
     rm -rf ./istio-${var.istio_helm_release_version} || true
-    curl -sL https://git.io/getLatestIstio | ISTIO_VERSION=${var.istio_helm_release_version} sh -
+    curl -sL https://raw.githubusercontent.com/istio/istio/master/release/downloadIstioCandidate.sh | ISTIO_VERSION=${var.istio_helm_release_version} sh -
     rm -rf ./istio || true
     mv ./istio-${var.istio_helm_release_version} istio
     sed -e 's|extensions/v1beta1|policy/v1beta1|g' istio/samples/security/psp/all-pods-psp.yaml > istio/install/kubernetes/helm/istio-init/templates/all-pods-psp.yaml


### PR DESCRIPTION
## Description

[git.io is shutting down on Friday](https://github.blog/changelog/2022-04-25-git-io-deprecation/). This change removes the short URL and just uses the long URL. 

## Related Issues

https://github.com/astronomer/issues/issues/4564

## Testing

This is a very small change that just expands the short URL into the long one. No testing is needed if CI passes.

## Merging

This change should be merged to every branch we support.